### PR TITLE
Update oodle.go: "is not resolve" → "could not be resolved"

### DIFF
--- a/oodle.go
+++ b/oodle.go
@@ -220,7 +220,7 @@ func resolveLibPath() (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("`%s` is not resolve", libName)
+	return "", fmt.Errorf("`%s` could not be resolved", libName)
 }
 
 func getTempDllPath() string {


### PR DESCRIPTION
This phrasing is pretty standard, and the old phrasing wasn't grammatically valid english.